### PR TITLE
Clarify copyright holder in 3-Clause BSD License

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -8,7 +8,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
+    * Neither the name of the ONNC Team nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 


### PR DESCRIPTION
The third clause mentions the copyright holder, which should refer to
ONNC Team.