### PR TITLE
Always use "macOS" while refering Apple's OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ ONNC increases DLA ASIC performance and shorten production time for DLA ASIC.
 
 ## Supported platforms
 
-ONNC supports Ubuntu/x86_64 and MacOSX.
+ONNC supports Ubuntu/x86_64 and macOS.
 
 Here is a list of verified versions:
 * Ubuntu/x86_64
   - 16.04
 
-* MacOSX
+* macOS
   - High Sierra
 
 ## Getting Started

--- a/include/onnc/IR/Quadruple.h
+++ b/include/onnc/IR/Quadruple.h
@@ -122,7 +122,7 @@ public:
     KFreeBSD,
     Linux,
     Lv2,        // PS3
-    MacOSX,
+    macOS,
     MinGW32,    // i*86-pc-mingw32, *-w64-mingw32
     NetBSD,
     OpenBSD,

--- a/lib/IR/Quadruple.cpp
+++ b/lib/IR/Quadruple.cpp
@@ -108,7 +108,7 @@ Quadruple::OSType onnc::ParseOS(StringRef pOSName)
     .StartsWith("kfreebsd", Quadruple::KFreeBSD)
     .StartsWith("linux", Quadruple::Linux)
     .StartsWith("lv2", Quadruple::Lv2)
-    .StartsWith("macosx", Quadruple::MacOSX)
+    .StartsWith("macos", Quadruple::macOS)
     .StartsWith("mingw32", Quadruple::MinGW32)
     .StartsWith("netbsd", Quadruple::NetBSD)
     .StartsWith("openbsd", Quadruple::OpenBSD)
@@ -381,7 +381,7 @@ const char* onnc::OSToName(Quadruple::OSType pType)
     case Quadruple::KFreeBSD:  return "kfreebsd";
     case Quadruple::Linux:     return "linux";
     case Quadruple::Lv2:       return "lv2";
-    case Quadruple::MacOSX:    return "macosx";
+    case Quadruple::macOS:     return "macos";
     case Quadruple::MinGW32:   return "mingw32";
     case Quadruple::NetBSD:    return "netbsd";
     case Quadruple::OpenBSD:   return "openbsd";


### PR DESCRIPTION
Since 2016, Apple rebrands its operating system from OS X to macOS,
and we should avoid using "MacOS X" for disambiguation.

Reference: https://en.wikipedia.org/wiki/MacOS