### PR TITLE
Address build failure against latest SkyPat

### DIFF
--- a/lib/Target/Sophon/BM188x/Tests/main.cpp
+++ b/lib/Target/Sophon/BM188x/Tests/main.cpp
@@ -10,7 +10,7 @@
 
 int main(int argc, char* argv[])
 {
-  skypat::Test::Initialize(&argc, argv);
+  skypat::Test::Initialize(argc, argv);
   skypat::Test::RunAll();
 
   return (skypat::testing::UnitTest::self()->getNumOfFails() == 0 ? EXIT_SUCCESS : EXIT_FAILURE);

--- a/tools/unittests/bitmain/llc/llcTest.cpp
+++ b/tools/unittests/bitmain/llc/llcTest.cpp
@@ -216,7 +216,7 @@ SKYPAT_F(llcTest, testOutDims) {
 
 int main(int argc, char* argv[])
 {
-  skypat::Test::Initialize(&argc, argv);
+  skypat::Test::Initialize(argc, argv);
   skypat::Test::RunAll();
 
   return (skypat::testing::UnitTest::self()->getNumOfFails() == 0 ? EXIT_SUCCESS : EXIT_FAILURE);

--- a/tools/unittests/main.cpp
+++ b/tools/unittests/main.cpp
@@ -10,7 +10,7 @@
 
 int main(int argc, char* argv[])
 {
-  skypat::Test::Initialize(&argc, argv);
+  skypat::Test::Initialize(argc, argv);
   skypat::Test::RunAll();
 
   return (skypat::testing::UnitTest::self()->getNumOfFails() == 0 ? EXIT_SUCCESS : EXIT_FAILURE);


### PR DESCRIPTION
`skypat::Test::Initialize()` no longer accepts pointer after this commit:
https://github.com/skymizer/SkyPat/commit/d5beabc300d03409eaf6d4e207a5148fdc31f406