### PR TITLE
Sophon: ignore nop operator in alloc step

### DIFF
--- a/lib/Target/Sophon/BM188x/Compute/Gemm.cpp
+++ b/lib/Target/Sophon/BM188x/Compute/Gemm.cpp
@@ -55,7 +55,10 @@ void BM188X::Gemm::init(const xNode &pNode)
 
 void BM188X::Gemm::print(std::ostream &pOS) const
 {
-  // TODO
+  pOS << m_Outputs[0]->getName() << " = " << name();
+  for (unsigned int i = 0; i < m_Inputs.size(); ++i) {
+    pOS << " " << m_Inputs[i]->getName();
+  }
 }
 
 void BM188X::Gemm::accept(ComputeVisitor& pV)

--- a/lib/Target/Sophon/BM188x/Compute/MaxPool.cpp
+++ b/lib/Target/Sophon/BM188x/Compute/MaxPool.cpp
@@ -28,7 +28,8 @@ BM188X::MaxPool::MaxPool(const IntsAttr& pKS)
 
 void BM188X::MaxPool::print(std::ostream& pOS) const
 {
-  // TODO
+  pOS << m_Outputs[0]->getName() << " = " << name() << " "
+      << m_Inputs[0]->getName();
 }
 
 void BM188X::MaxPool::accept(ComputeVisitor& pV)

--- a/lib/Target/Sophon/BM188x/Compute/PRelu.cpp
+++ b/lib/Target/Sophon/BM188x/Compute/PRelu.cpp
@@ -32,7 +32,8 @@ BM188X::PRelu::~PRelu()
 
 void BM188X::PRelu::print(std::ostream &pOS) const
 {
-  // TODO
+  pOS << m_Outputs[0]->getName() << " = " << name() << " "
+      << m_Inputs[0]->getName() << " " << m_Inputs[1]->getName();
 }
 
 void BM188X::PRelu::accept(ComputeVisitor& pV)

--- a/lib/Target/Sophon/BM188x/GenRuntimeInfoPass.cpp
+++ b/lib/Target/Sophon/BM188x/GenRuntimeInfoPass.cpp
@@ -288,6 +288,7 @@ void GenRuntimeInfoPass::GenMemoryLayout(json::Object& pOutput,
       onnc::json::Object jMem;
       const ComputeMemOperand *opnd =
           backend()->getMemOpndByValue(inst->getInput(i));
+      assert(opnd != nullptr);
       jMem.insert("addr", onnc::json::Value(opnd->start()));
       jMem.insert("size", onnc::json::Value(opnd->length()));
       jLayer.insert(inst->getInput(i)->getName(), jMem);

--- a/lib/Target/Sophon/BuildMemOpndPass.cpp
+++ b/lib/Target/Sophon/BuildMemOpndPass.cpp
@@ -5,6 +5,8 @@
 // See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "tg_build_memop"
 #include "BuildMemOpndPass.h"
 #include <onnc/Core/ModulePass.h>
 #include <onnc/Core/PassSupport.h>
@@ -68,6 +70,8 @@ void BuildMemOpnd::createMemOperandsOfNode(ComputeGraph &pCG,
     }
     assert(inputCMO != nullptr);
     m_ValOperandMap.emplace_back(inputCMO, outputValue);
+    DEBUG(dbgs() << "insert ValOperandMap: " << inputCMO << ","
+                 << outputValue->getName() << "\n");
     return;
   }
   unsigned int out_size = pNode.getNumOfOutputs();
@@ -80,6 +84,8 @@ void BuildMemOpnd::createMemOperandsOfNode(ComputeGraph &pCG,
         pCG.addOperand<ComputeMemOperand>(pNode, *use->getUser(),
                                           *value, pResd);
       m_ValOperandMap.emplace_back(memOperand, value);
+      DEBUG(dbgs() << "insert ValOperandMap: " << memOperand << ","
+                   << value->getName() << "\n");
     }
   }
 }


### PR DESCRIPTION
reshape is nop operator in Sophon backend
we don't need to prepare memory for it

Thanks!