### PR TITLE
Sophon: enable GenWeightPass

### DIFF
--- a/lib/Target/Sophon/BM188x/BM188xBackend.cpp
+++ b/lib/Target/Sophon/BM188x/BM188xBackend.cpp
@@ -120,7 +120,7 @@ void BM1880Backend::addCodeEmit(PassManager &pPM, const Path &pOutputFile)
 {
   static BM188X::CodeEmitVisitor ceVisitor(this);
   pPM.add(BM188X::CreateGenRuntimeInfoPass(this, pOutputFile));
-  //pPM.add(BM188X::CreateGenWeightPass(this, pOutputFile));
+  pPM.add(BM188X::CreateGenWeightPass(this, pOutputFile));
   pPM.add(BM188X::CreateEncodeInstsPass(&ceVisitor, pOutputFile.native()));
 }
 

--- a/lib/Target/Sophon/BM188x/FillWeightVisitor.cpp
+++ b/lib/Target/Sophon/BM188x/FillWeightVisitor.cpp
@@ -6,9 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 #include "FillWeightVisitor.h"
-#include <onnc/IR/Compute/Initializer.h>
 #include "Compute/Conv.h"
+#include "Compute/Gemm.h"
+#include "Compute/LRN.h"
+#include "Compute/PRelu.h"
 #include "Compute/SlicedConv.h"
+#include <onnc/IR/Compute/Initializer.h>
 
 using namespace onnc;
 using namespace onnc::BM188X;
@@ -16,138 +19,169 @@ using namespace onnc::BM188X;
 //===----------------------------------------------------------------------===//
 // Non-member functions
 //===----------------------------------------------------------------------===//
-static const std::string *GetRaw(const onnc::Tensor* pT)
+
+static const std::vector<int8_t> &getInt8Data(const onnc::Value *pValue)
 {
-  return &pT->adaptee()->raw();
+  auto *tensor = dynamic_cast<const onnc::Int8Tensor *>(pValue);
+  return tensor->getValues();
 }
 
-static const xTensor *
-GetTensor(const BM188X::SlicedConv& pConv, unsigned int pIdx)
+static const std::vector<int16_t> &getInt16Data(const onnc::Value *pValue)
 {
-  switch(pIdx) {
-    case 0: return pConv.getInput(0)->adaptee();
-    case 1: return pConv.getInput(1)->adaptee();
-    case 2: return pConv.getOutput(0)->adaptee();
-    case 3: return pConv.getInput(2)->adaptee();
-  }
-  return nullptr;
+  auto *tensor = dynamic_cast<const onnc::Int16Tensor *>(pValue);
+  return tensor->getValues();
 }
 
 //===----------------------------------------------------------------------===//
 // FillWeightVisitor
 //===----------------------------------------------------------------------===//
-FillWeightVisitor::FillWeightVisitor(GenWeightPass::WeightType& pWeight)
+FillWeightVisitor::FillWeightVisitor(GenWeightPass::WeightType &pWeight)
     : m_Weight(pWeight), m_DoneOpndSet()
 {
 }
 
-void FillWeightVisitor::visit(const onnc::Initializer &pOp)
-{
-  const onnc::Value* value = pOp.getOutput<onnc::Value>();
-  const std::string& raw = value->adaptee()->raw();
-
-  if (onnc::Value::kInt8 == value->kind())
-    Append8bit(m_Weight, raw);
-  else
-    Append16bit(m_Weight, raw);
-}
-
 // visit TGConv
-void FillWeightVisitor::visit(const BM188X::Conv& pConv)
+void FillWeightVisitor::visit(const BM188X::Conv &pConv)
 {
   Weight weight;
-  weight.resize(onnc::getTotalCount(pConv.getInput(1)->adaptee()->sizes()));
 
+  auto *input = dynamic_cast<const onnc::Int8Tensor *>(pConv.getInput(0));
+  auto *int8_weight = dynamic_cast<const onnc::Int8Tensor *>(pConv.getInput(1));
+  assert(input->getNumOfDimensions() == 4);
+  assert(int8_weight->getNumOfDimensions() == 4);
+
+  std::vector<int8_t> weight_data = int8_weight->getValues();
+  assert(weight_data.size() != 0);
+  weight.resize(weight_data.size());
+
+  // ks is kh * kw
   int ks = pConv.getKernelShape().at(0) * pConv.getKernelShape().at(1);
-  int ic = pConv.getInput(0)->adaptee()->sizes().at(1) / pConv.getGroup();
-  int oc = pConv.getInput(1)->adaptee()->sizes().at(0);
-  const std::string& raw = pConv.getInput(1)->adaptee()->raw();
-  Convert(weight, raw, ks, ic, oc);
+  int ic = input->dimension(1) / pConv.getGroup();
+  int oc = int8_weight->dimension(0);
+  Convert(weight, weight_data, ks, ic, oc);
 
   // 16bit bias
-  if (pConv.isDoBias())
-    Append16bit(weight, *GetRaw(pConv.getBias()));
+  if (pConv.isDoBias()) {
+    const std::vector<int16_t> data = getInt16Data(pConv.getInput(2));
+    Append16bit(weight, data);
+  }
 
-  // 8bit scale bias
-  if (pConv.isDoScale())
-    Append8bit(weight, *GetRaw(pConv.getScale()));
+  // 8bit scale
+  if (pConv.isDoScale()) {
+    const std::vector<int8_t> data = getInt8Data(pConv.getScale());
+    Append8bit(weight, data);
+  }
 
   // 16bit scale bias
-  if (pConv.isDoScaleBias())
-    Append16bit(weight, *GetRaw(pConv.getScaleBias()));
+  if (pConv.isDoScaleBias()) {
+    const std::vector<int16_t> data = getInt16Data(pConv.getScaleBias());
+    Append16bit(weight, data);
+  }
 
   // update weight
   m_Weight.insert(m_Weight.end(), weight.begin(), weight.end());
 }
 
 // visit TLConv
-void FillWeightVisitor::visit(const BM188X::SlicedConv& pConv)
+void FillWeightVisitor::visit(const BM188X::SlicedConv &pConv)
 {
   Weight weight;
-  const xTensor* tensor = pConv.getInput(1)->adaptee();
-  if (!isWritten(*tensor)) {
-    setWritten(*tensor);
-    weight.resize(onnc::getTotalCount(tensor->sizes()));
+  auto *int8_weight = dynamic_cast<const onnc::Int8Tensor *>(pConv.getInput(1));
+  assert(int8_weight->getNumOfDimensions() == 4);
+
+  if (!isWritten(*int8_weight)) {
+    setWritten(*int8_weight);
+
+    std::vector<int8_t> weight_data = int8_weight->getValues();
+    assert(weight_data.size() != 0);
+    weight.resize(weight_data.size());
+
+    auto *input = dynamic_cast<const onnc::Int8Tensor *>(pConv.getInput(0));
+    assert(input->getNumOfDimensions() == 4);
 
     int ks = pConv.getKernelShape().at(0) * pConv.getKernelShape().at(1);
-    int ic = pConv.getInDim().at(1) / pConv.getGroups();
-    int oc = pConv.getOutDim().at(1);
-    Convert(weight, tensor->raw(), ks, ic, oc);
+    int ic = input->dimension(1) / pConv.getGroups();
+    int oc = int8_weight->dimension(0);
+    Convert(weight, weight_data, ks, ic, oc);
   }
 
-  if (1 == pConv.getDoBias()) {
-    const xTensor* tensor = GetTensor(pConv, pConv.getBiasIdx());
-    if (!isWritten(*tensor)) {
-      setWritten(*tensor);
-      Append16bit(weight, tensor->raw());
-    }
+  if (pConv.getDoBias() && !isWritten(*pConv.getInput(2))) {
+    auto *int16_weight =
+        dynamic_cast<const onnc::Int16Tensor *>(pConv.getInput(2));
+    setWritten(*int16_weight);
+    const std::vector<int16_t> weight_data = int16_weight->getValues();
+    Append16bit(weight, weight_data);
   }
-
   // update weight
   m_Weight.insert(m_Weight.end(), weight.begin(), weight.end());
+}
+
+void FillWeightVisitor::visit(const BM188X::Gemm &pGemm)
+{
+  const std::vector<int8_t> weight_data = getInt8Data(pGemm.getInput(1));
+  Append8bit(m_Weight, weight_data);
+  const std::vector<int16_t> bias_data = getInt16Data(pGemm.getInput(2));
+  Append16bit(m_Weight, bias_data);
+}
+
+void FillWeightVisitor::visit(const BM188X::LRN &pLRN)
+{
+  const std::vector<int8_t> sqrlut_data = getInt8Data(pLRN.getInput(1));
+  Append8bit(m_Weight, sqrlut_data);
+  const std::vector<int8_t> powerlut_data = getInt8Data(pLRN.getInput(2));
+  Append8bit(m_Weight, powerlut_data);
+}
+
+void FillWeightVisitor::visit(const BM188X::PRelu &pPRelu)
+{
+  const std::vector<int8_t> slope_data = getInt8Data(pPRelu.getInput(1));
+  Append8bit(m_Weight, slope_data);
 }
 
 //===----------------------------------------------------------------------===//
 // FillWeightVisitor support members
 //===----------------------------------------------------------------------===//
-void FillWeightVisitor::Convert(Weight& pWeight, const std::string& pRaw,
-                                int pKS, int pIC, int pOC)
+void FillWeightVisitor::Convert(Weight &pWeight,
+                                const std::vector<int8_t> &pData, int pKS,
+                                int pIC, int pOC)
 {
+  // pKS is kh*kw
   // conv weight is arranged by (1, oc, kh*kw, ic)
   // convert (oc, ic, kh, kw) to (1, oc, kh*kw, ic)
   for (int oc_i = 0; oc_i < pOC; ++oc_i) {
     for (int k_i = 0; k_i < pKS; ++k_i) {
       for (int ic_i = 0; ic_i < pIC; ++ic_i) {
-        int to   = oc_i*pKS*pIC + k_i  * pIC + ic_i;
-        int from = oc_i*pKS*pIC + ic_i * pKS + k_i;
-        pWeight[to] = (int8_t)pRaw[from];
+        int to = oc_i * (pKS * pIC) + k_i * pIC + ic_i;
+        int from = oc_i * (pKS * pIC) + ic_i * pKS + k_i;
+        pWeight[to] = pData[from];
       }
     }
   }
 }
 
-void FillWeightVisitor::Append8bit(Weight& pW, const std::string &pRaw)
+void FillWeightVisitor::Append8bit(Weight &pW, const std::vector<int8_t> &pData)
 {
-  std::copy(pRaw.begin(), pRaw.end(), std::back_inserter(pW));
+  std::copy(pData.begin(), pData.end(), std::back_inserter(pW));
 }
 
-void FillWeightVisitor::Append16bit(Weight& pW, const std::string &pRaw)
+void FillWeightVisitor::Append16bit(Weight &pW,
+                                    const std::vector<int16_t> &pData)
 {
-  size_t count = pRaw.size();
+  size_t count = pData.size();
   size_t offset = pW.size();
   pW.resize(offset + count * 2);
-  for (size_t i = 0; i*2 < count; ++i) {
-    pW[offset + i] = (int8_t)pRaw[i*2];
-    pW[offset + i + count] = (int8_t)pRaw[i*2 + 1];
+  for (size_t i = 0; i < count; ++i) {
+    pW[offset + i] = (int8_t)(pData[i] & 0xff);
+    pW[offset + i + count] = (int8_t)(pData[i] >> 8 & 0xff);
   }
 }
 
-bool FillWeightVisitor::isWritten(const xTensor &pOpnd) const
+bool FillWeightVisitor::isWritten(const onnc::Value &pValue) const
 {
-  return (m_DoneOpndSet.end() != m_DoneOpndSet.find(&pOpnd));
+  return (m_DoneOpndSet.end() != m_DoneOpndSet.find(&pValue));
 }
 
-void BM188X::FillWeightVisitor::setWritten(const xTensor &pOpnd)
+void BM188X::FillWeightVisitor::setWritten(const onnc::Value &pValue)
 {
-  m_DoneOpndSet.insert(&pOpnd);
+  m_DoneOpndSet.insert(&pValue);
 }

--- a/lib/Target/Sophon/BM188x/FillWeightVisitor.h
+++ b/lib/Target/Sophon/BM188x/FillWeightVisitor.h
@@ -10,6 +10,7 @@
 #include "BM188xVisitor.h"
 #include "GenWeightPass.h"
 #include <assert.h>
+#include <onnc/IR/Compute/Tensor.h>
 
 namespace onnc {
 namespace BM188X {
@@ -22,30 +23,34 @@ public:
 public:
   using BM188xVisitor::visit;
 
-  void visit(const onnc::Initializer &pOp) override;
-
   void visit(const BM188X::Conv& pConv) override;
 
   void visit(const BM188X::SlicedConv& pSlicedConv) override;
+
+  void visit(const BM188X::Gemm &pGemm) override;
+
+  void visit(const BM188X::LRN &pLRN) override;
+
+  void visit(const BM188X::PRelu &pPRelu) override;
 
   FillWeightVisitor(Weight& pWeight);
 
 private:
   /// remember the written TLConv's memory operands to prevent from
   /// duplicatedly written.
-  typedef std::unordered_set<const xTensor*> DoneOpndSet;
+  typedef std::unordered_set<const onnc::Value *> DoneOpndSet;
 
 private:
-  static void Convert(Weight& pWeight, const std::string& pRaw,
+  static void Convert(Weight &pWeight, const std::vector<int8_t> &pData,
                       int pKS, int pIC, int pOC);
 
-  static void Append8bit(Weight& pW, const std::string &pData);
+  static void Append8bit(Weight &pW, const std::vector<int8_t> &pData);
 
-  static void Append16bit(Weight& pW, const std::string &pData);
+  static void Append16bit(Weight &pW, const std::vector<int16_t> &pData);
 
-  bool isWritten(const xTensor& pOpnd) const;
+  bool isWritten(const onnc::Value &pValue) const;
 
-  void setWritten(const xTensor& pOpnd);
+  void setWritten(const onnc::Value &pValue);
 
 private:
   Weight& m_Weight;


### PR DESCRIPTION
1. pValue->adaptee() is nullptr, changed to use tensor data
2. remove Initializer visitor, it would handle the same value twice. (ex. conv)
3. add other operator's visitor

Thanks!