### PR TITLE
Sophon: fix memory allocation order issue

### DIFF
--- a/lib/Target/Sophon/BM188x/GenWeightPass.cpp
+++ b/lib/Target/Sophon/BM188x/GenWeightPass.cpp
@@ -62,6 +62,7 @@ void BM188X::GenWeightPass::fillWeight(const Module& pModule)
 
   FillWeightVisitor visitor(m_Weight);
   Module::const_cg_iterator cg, cEnd = pModule.cgEnd();
+  // ps. currently traverse memory order need to sync with LinearScanAllocPass
   for (cg = pModule.cgBegin(); cg != cEnd; ++cg) {
     const ComputeGraph* graph = cg->value();
     ComputeGraph::const_iterator node, nEnd = graph->end();

--- a/lib/Target/Sophon/BuildMemOpndPass.h
+++ b/lib/Target/Sophon/BuildMemOpndPass.h
@@ -16,8 +16,8 @@ namespace onnc {
 class BuildMemOpnd : public ModulePass
 {
 public:
-  typedef std::vector<std::pair<ComputeMemOperand*, onnc::Value*>>
-          MemOperandValList;
+  typedef std::map<const onnc::Value *, ComputeMemOperand *> ValMemOpndMap;
+
 public:
   static char ID;
 
@@ -25,12 +25,12 @@ public:
   BuildMemOpnd();
 
   StringRef getPassName() const override { return "BuildMemOpnd"; }
-  
+
   Pass::ReturnType runOnModule(::onnc::Module &pModule) override;
 
-  const MemOperandValList &getMemOperandList() const
+  const ValMemOpndMap &getMemOperandList() const
   {
-    return m_ValOperandMap;
+    return m_ValMemOpndMap;
   }
 
 private:
@@ -42,7 +42,7 @@ private:
   void clear();
 
 private:
-  MemOperandValList m_ValOperandMap;
+  ValMemOpndMap m_ValMemOpndMap;
 };
 
 ModulePass *CreateBuildMemOpndPass();

--- a/lib/Target/Sophon/LinearScanAllocPass.h
+++ b/lib/Target/Sophon/LinearScanAllocPass.h
@@ -29,13 +29,19 @@ public:
   void getAnalysisUsage(AnalysisUsage& pUsage) const override;
 
 private:
-  void linearScanAlloMem(const BuildMemOpnd::MemOperandValList &pMemOps);
+  void linearScanAllocMem(const ComputeGraph &pCG,
+                          const BuildMemOpnd::ValMemOpndMap &pValMemOpndMap);
+
+  void memoryAlloc(ComputeMemOperand *pMemOp, const onnc::Value *pMemVal);
 
 private:
   // for sizeOfTensorType.
   // FIXME: Use DLATargetBackend instead.
   //        sizeofTensorType is used on compute ir with legalized value type
   TGBackend *m_pTarget; // NOLINT
+  unsigned int m_WeightOffset;
+  unsigned int m_NeuronOffset;
+  std::unordered_set<ComputeMemOperand*> m_AllocatedMemOpnd;
 };
 
 ModulePass *CreateLinearScanAllocPass(TGBackend *pTarget);


### PR DESCRIPTION
1. weight data need to arranged in execution order
2. LinearScanAllocPass: chagned allocate order by
   execution order
3. BuildMemOpndPass: changed list to map

Thanks.