### PR TITLE
Sophon: restore 'new BM188xTargetMemInfo'

### DIFF
--- a/lib/Target/Sophon/BM188x/BM188xBackend.cpp
+++ b/lib/Target/Sophon/BM188x/BM188xBackend.cpp
@@ -69,6 +69,7 @@ using namespace onnc;
 BM1880Backend::BM1880Backend(const TargetOptions &pOptions)
     : TGBackend(pOptions)
 {
+  m_pMemInfo = new BM188xTargetMemInfo(this);
   m_pTTI = new BM188xTargetTransformInfo(this);
 }
 


### PR DESCRIPTION
This is to restore initialization of m_pMemInfo in BM188xBackend,
which is previously removed in 990857d7.