### PR TITLE
Issue57 replace output bug

### DIFF
--- a/include/onnc/IR/ComputeGraph.h
+++ b/include/onnc/IR/ComputeGraph.h
@@ -89,6 +89,8 @@ public:
 
   void erase(Arc& pArc);
 
+  void erase(Value& pVal);
+
   void clear();
 
   void getRear(Node*& pNode) const { pNode = m_pNodeRear; }

--- a/lib/IR/ComputeGraph.cpp
+++ b/lib/IR/ComputeGraph.cpp
@@ -108,6 +108,14 @@ void ComputeGraph::erase(ComputeOperand& pArc)
   delete &pArc;
 }
 
+void ComputeGraph::erase(Value& pVal)
+{
+  assert(pVal.getDefine() == nullptr && "Define still exist.");
+  assert(pVal.getUses().empty() && "User list is not empty.");
+  m_ValueList.erase(pVal.getName());
+  delete &pVal;
+}
+
 void ComputeGraph::clear()
 {
   m_pNodeHead = nullptr;

--- a/lib/IR/ComputeOperator.cpp
+++ b/lib/IR/ComputeOperator.cpp
@@ -64,6 +64,7 @@ void ComputeOperator::replaceOutput(unsigned int pIdx, onnc::Value &pValue)
   if (pIdx >= m_Outputs.size())
     fatal(input_out_of_range) << pIdx << name() << (uint32_t)m_Outputs.size();
   m_Outputs[pIdx]->clearDefine();
+  m_Outputs[pIdx]->replaceAllUsesWith(pValue);
   m_Outputs[pIdx] = &pValue;
   pValue.setDefine(this, pIdx);
 }

--- a/lib/IR/Module.cpp
+++ b/lib/IR/Module.cpp
@@ -140,6 +140,12 @@ Module::~Module()
   }
   m_RootTensorGraph.reset();
 
+  for (auto entry : m_ComputeGraphs) {
+    ComputeGraph* cg = entry.value();
+    delete cg;
+  }
+  m_ComputeGraphs.clear();
+
   for (auto entry : m_Values) {
     Value* v = entry.value();
     delete v;


### PR DESCRIPTION
This PR fixes:
1. https://github.com/ONNC/onnc/issues/57
    (ComputeOperator::replaceOutput() have to update Value's use_list)
2. Delete all onnc::ComputeGraph in Module destructor.
