### PR TITLE
Implement linear memory allocation

### DIFF
--- a/include/onnc/CodeGen/BuildMemOperand.h
+++ b/include/onnc/CodeGen/BuildMemOperand.h
@@ -1,0 +1,56 @@
+//===- BuildMemOperandPass.h ----------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef ONNC_CODEGEN_BUILD_MEM_OPERAND_H
+#define ONNC_CODEGEN_BUILD_MEM_OPERAND_H
+#include <onnc/Core/ModulePass.h>
+
+namespace onnc {
+
+/** \class BuildMemOperand
+ *  \brief In onnc, ComputeMemOperand refers to an edge of an input-output-pair.
+ *         This pass build memory operands for a given compute graph.
+ *
+ *         ComputeMemOperand has two usages:
+ *         1. Allows later pass can use dfs/bfs traversing algorithms
+ *            provided by ComputeGraph to traverse graph.
+ *
+ *         2. Memory allocation pass write allocation result into
+ *            ComputeMemOperand, code emit pass or onnc-jit can use it to
+ *            allocate memory on target.
+ *
+ *  \note  ComputeMemOperands which hold the same onnc::Value should have the
+ *         same start and length, so even though AN onnc::Value maps to
+ *         M x onnc::ComputeMemOperand, but these M x onnc::ComputeMemOperand
+ *         should have the same memory allocation information.
+ */
+class BuildMemOperand : public ModulePass
+{
+public:
+  static char ID;
+
+public:
+  BuildMemOperand()
+    : ModulePass(ID) {
+  }
+
+  StringRef getPassName() const override { return "BuildMemOperand"; }
+
+  Pass::ReturnType runOnModule(Module &pModule) override;
+
+private:
+  void createMemOperandsOfNode(ComputeGraph &pCG, ComputeOperator &pNode,
+                               ComputeOperand::Residence pResd);
+
+  void createMemOperandsOfGraph(ComputeGraph &pCG);
+};
+
+ModulePass* CreateBuildMemOperandPass();
+
+} // namespace onnc
+
+#endif

--- a/include/onnc/CodeGen/LinearScanMemAlloc.h
+++ b/include/onnc/CodeGen/LinearScanMemAlloc.h
@@ -1,0 +1,86 @@
+//===- LinearScanMemAlloc.h -----------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef ONNC_CODEGEN_LINEAR_SCAN_MEM_ALLOC_H
+#define ONNC_CODEGEN_LINEAR_SCAN_MEM_ALLOC_H
+#include <onnc/Core/ModulePass.h>
+
+namespace onnc {
+
+class LiveInterval;
+class LiveIntervals;
+class LiveValueMatrix;
+class TargetBackend;
+class TargetMemInfo;
+
+/** \class LinearScanMemAlloc
+ *  \brief Linear memory allocation for each value considering value's liveness.
+ */
+class LinearScanMemAlloc : public ModulePass
+{
+public:
+  static char ID;
+
+  struct AllocEntry
+  {
+    uint64_t startAddr, size;
+    AllocEntry(uint64_t pStartAddr, uint64_t pSize)
+      : startAddr(pStartAddr), size(pSize) {
+    }
+
+    AllocEntry()
+      : startAddr(0), size(0) {
+    }
+
+    bool overlap(const AllocEntry& pOther)
+    {
+      uint64_t myEnd = startAddr + size,
+               otherEnd = pOther.startAddr + pOther.size;
+      return !(myEnd <= pOther.startAddr || otherEnd <= startAddr);
+    }
+  };
+
+  typedef std::unordered_map<Value*, AllocEntry> ValToAllocEntry;
+
+  typedef std::vector<AllocEntry> AllocEntries;
+
+  typedef std::vector<LiveInterval*> LIs;
+
+public:
+  LinearScanMemAlloc(TargetBackend* pTarget = nullptr);
+
+  StringRef getPassName() const override { return "LinearScanMemAlloc"; }
+
+  Pass::ReturnType runOnModule(Module &pModule) override;
+
+  void getAnalysisUsage(AnalysisUsage& pUsage) const override;
+
+  AllocEntry getAlloc(const Value* pVal) const;
+
+  void print(std::ostream& pOS) const;
+
+  void dump() const;
+
+private:
+  AllocEntries getSortedAllocatedRegions(const LIs& pLIs) const;
+
+  AllocEntry getAnEmptyRegion(const AllocEntries& pAllocs,
+                              uint64_t pRequiredSize,
+                              uint64_t pAlignment) const;
+
+private:
+  ValToAllocEntry m_ValToAllocEntry;
+  LiveIntervals* m_LIPass;
+  LiveValueMatrix* m_LiveMatPass;
+  TargetMemInfo* m_TMI;
+};
+
+ModulePass* CreateLinearScanMemAllocPass(TargetBackend* pTB);
+
+} // namespace onnc
+
+#endif

--- a/include/onnc/Target/DLATargetBackend.h
+++ b/include/onnc/Target/DLATargetBackend.h
@@ -20,16 +20,7 @@ public:
     : TargetBackend(pOptions) {
   }
 
-  virtual ~DLATargetBackend(){}
-
-  /// This is not a constant function. Because there in case memory emulator
-  /// must change its internal state.
-  TargetMemInfo* getMemInfo() { return m_pMemInfo; }
-
-  const TargetMemInfo* getMemInfo() const { return m_pMemInfo; }
-
-protected:
-  TargetMemInfo* m_pMemInfo;
+  virtual ~DLATargetBackend() {}
 };
 
 } // namespace of onnc

--- a/include/onnc/Target/TargetBackend.h
+++ b/include/onnc/Target/TargetBackend.h
@@ -22,7 +22,7 @@ class TargetBackend
 {
 public:
   TargetBackend(const TargetOptions& pOptions)
-    : m_TargetOptions(pOptions) {
+    : m_pMemInfo(nullptr), m_TargetOptions(pOptions) {
   }
 
   virtual ~TargetBackend() { }
@@ -41,6 +41,15 @@ public:
   virtual void RegisterLowers(LowerRegistry& pRegistry) const { return; }
 
   const TargetOptions& options() const { return m_TargetOptions; }
+
+  /// This is not a constant function. Because there in case memory emulator
+  /// must change its internal state.
+  TargetMemInfo* getMemInfo() { return m_pMemInfo; }
+
+  const TargetMemInfo* getMemInfo() const { return m_pMemInfo; }
+
+protected:
+  TargetMemInfo* m_pMemInfo;
 
 private:
   const TargetOptions& m_TargetOptions;

--- a/include/onnc/Target/TargetMemInfo.h
+++ b/include/onnc/Target/TargetMemInfo.h
@@ -12,6 +12,8 @@
 
 namespace onnc {
 
+class Tensor;
+
 typedef xTensorProtoDataType TP_DataTy;
 
 /** \struct MemSize
@@ -46,6 +48,11 @@ public:
 
   /// Return actual memory size and alignment requirement of xValue.
   virtual MemSize getValueMemorySize(xValue *pValue) {
+    return MemSize();
+  }
+
+  /// Return actual memory size and alignment requirement of onnc Tensor.
+  virtual MemSize getTensorMemorySize(const Tensor& pVal) {
     return MemSize();
   }
 };

--- a/lib/CodeGen/BuildMemOperand.cpp
+++ b/lib/CodeGen/BuildMemOperand.cpp
@@ -1,0 +1,78 @@
+//===- BuildMemOperandPass.cpp --------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include <onnc/CodeGen/BuildMemOperand.h>
+#include <onnc/Core/PassSupport.h>
+#include <onnc/IR/Compute/Cast.h>
+#include <onnc/IR/Compute/Initializer.h>
+#include <onnc/IR/Compute/InputOperator.h>
+#include <onnc/IR/Compute/OutputOperator.h>
+#include <onnc/Support/Debug.h>
+#include <onnc/Support/IOStream.h>
+
+using namespace onnc;
+
+//===----------------------------------------------------------------------===//
+// BuildMemOperand
+//===----------------------------------------------------------------------===//
+Pass::ReturnType BuildMemOperand::runOnModule(Module& pModule)
+{
+  Module::cg_iterator cg, cgEnd = pModule.cgEnd();
+  for (cg = pModule.cgBegin(); cg != cgEnd; ++cg)
+    createMemOperandsOfGraph(*cg->value());
+
+  return Pass::kModuleNoChanged;
+}
+
+void BuildMemOperand::createMemOperandsOfGraph(ComputeGraph& pCG)
+{
+  ComputeGraph::iterator nodeIt, nEnd = pCG.end();
+  for (nodeIt = pCG.begin(); nodeIt != nEnd; ++nodeIt) {
+    ComputeOperator *node = nodeIt;
+    ComputeOperand::Residence resd;
+    if (isa<Initializer>(node))
+      resd = ComputeOperand::kWeightResidence;
+    else if (isa<InputOperator>(node))
+      resd = ComputeOperand::kInputResidence;
+    else if (isa<OutputOperator>(node))
+      resd = ComputeOperand::kOutputResidence;
+    else
+      resd = ComputeOperand::kInternalResidence;
+
+    createMemOperandsOfNode(pCG, *node, resd);
+  }
+}
+
+void BuildMemOperand::createMemOperandsOfNode(ComputeGraph& pCG,
+                                              ComputeOperator& pNode,
+                                              ComputeOperand::Residence pResd)
+{
+  // Create memory operand for each output value
+  for (unsigned i = 0; i < pNode.getNumOfOutputs(); ++i) {
+    onnc::Value* value = pNode.getOutput(i);
+    for (auto& use : value->getUses()) {
+      pCG.addOperand<ComputeMemOperand>(pNode, *use.getUser(),
+                                        *value, pResd);
+
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Factory method
+//===----------------------------------------------------------------------===//
+char BuildMemOperand::ID = 0;
+
+namespace onnc
+{
+  INITIALIZE_PASS(BuildMemOperand, "BuildMemOperand")
+}
+
+ModulePass* onnc::CreateBuildMemOperandPass()
+{
+  return new BuildMemOperand();
+}

--- a/lib/CodeGen/CMakeLists.txt
+++ b/lib/CodeGen/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_libonnc_src(
+    BuildMemOperand.cpp
     LiveInterval.cpp
     LiveIntervals.cpp
     LiveValueMatrix.cpp

--- a/lib/CodeGen/CMakeLists.txt
+++ b/lib/CodeGen/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_libonnc_src(
     BuildMemOperand.cpp
+    LinearScanMemAlloc.cpp
     LiveInterval.cpp
     LiveIntervals.cpp
     LiveValueMatrix.cpp

--- a/lib/CodeGen/LinearScanMemAlloc.cpp
+++ b/lib/CodeGen/LinearScanMemAlloc.cpp
@@ -1,0 +1,183 @@
+//===- LinearScanMemAlloc.cpp ---------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include <onnc/CodeGen/LinearScanMemAlloc.h>
+#include <onnc/CodeGen/LiveIntervals.h>
+#include <onnc/CodeGen/LiveValueMatrix.h>
+#include <onnc/Core/PassAnalysisSupport.h>
+#include <onnc/Core/PassSupport.h>
+#include <onnc/Target/TargetBackend.h>
+#include <onnc/Target/TargetMemInfo.h>
+#include <iomanip>
+
+using namespace onnc;
+
+/// Check if two segment A overlaps segment B.
+///   segment A = [pStartA, pStartA + pSizeA)
+///   segment B = [pStartB, pStartB + pSizeB)
+static bool HasConflict(uint64_t pStartA, uint64_t pSizeA,
+                        uint64_t pStartB, uint64_t pSizeB)
+{
+  uint64_t endA = pStartA + pSizeA,
+           endB = pStartB + pSizeB;
+
+  return !(endA <= pStartB || endB <= pStartA);
+}
+
+static uint64_t GetAlignedAddr(uint64_t pAddr, uint64_t pAlignment)
+{
+  assert(pAlignment > 0 && ((pAlignment & (pAlignment - 1)) == 0) &&
+         "Alignment should be powerof 2.");
+  pAddr += pAlignment - 1;
+  pAddr &= ~(pAlignment - 1);
+  return pAddr;
+}
+
+//===----------------------------------------------------------------------===//
+// LinearScanMemAlloc
+//===----------------------------------------------------------------------===//
+LinearScanMemAlloc::LinearScanMemAlloc(TargetBackend* pTarget)
+  : ModulePass(ID), m_ValToAllocEntry(),
+    m_LIPass(nullptr), m_LiveMatPass(nullptr) {
+  m_TMI = pTarget->getMemInfo();
+}
+
+Pass::ReturnType LinearScanMemAlloc::runOnModule(Module& pModule)
+{
+  m_LIPass = getAnalysis<LiveIntervals>();
+  m_LiveMatPass = getAnalysis<LiveValueMatrix>();
+
+  AllocEntries curAllocs;
+
+  // Allocate memory for each value (live interval).
+  for (const LiveInterval* LI: m_LIPass->getSortedIntervals()) {
+    LiveIntervals::LIs overlappedLIs =
+      m_LiveMatPass->getInterferingLiveIntervals(LI);
+
+    AllocEntries allocRegions = getSortedAllocatedRegions(overlappedLIs);
+
+    Value* v = const_cast<Value*>(LI->getValue());
+
+    // FIXME: Do we have safer casting? We should check before casting.
+    MemSize m = m_TMI->getTensorMemorySize(*(Tensor*)v);
+
+    m_ValToAllocEntry[v] =
+      getAnEmptyRegion(allocRegions, m.size, m.alignment);
+  }
+  return Pass::kModuleNoChanged;
+}
+
+void LinearScanMemAlloc::getAnalysisUsage(AnalysisUsage& pUsage) const
+{
+  pUsage.addRequiredID(LiveValueMatrix::ID);
+}
+
+LinearScanMemAlloc::AllocEntry
+LinearScanMemAlloc::getAlloc(const Value* pVal) const
+{
+  auto it = m_ValToAllocEntry.find(const_cast<Value*>(pVal));
+  assert(it != m_ValToAllocEntry.end() &&
+         "Value has no memory allocation.");
+  return it->second;
+}
+
+void LinearScanMemAlloc::print(std::ostream& pOS) const
+{
+  pOS << "=== LinearScanMemAlloc ===\n";
+
+  if (m_ValToAllocEntry.empty()) {
+    pOS << "Empty.\n";
+    return;
+  }
+
+  std::stringstream dbgstr;
+  dbgstr << std::hex << std::left
+         << std::setw(20) << "value:" << std::setw(12) << "start"
+         << std::setw(12) << "end"
+         << "\n";
+
+  uint64_t maxEnd = 0;
+
+  for (const LiveInterval* li : m_LIPass->getSortedIntervals()) {
+    Value* v = const_cast<Value*>(li->getValue());
+    AllocEntry alloc = m_ValToAllocEntry.find(v)->second;
+    uint64_t endAddr = alloc.startAddr + alloc.size;
+    maxEnd = std::max(maxEnd, endAddr);
+
+    dbgstr << std::left << std::setw(20) << std::setfill(' ') << v->getName()
+           << "0x"
+           << std::right << std::setw(8) << std::setfill('0') << alloc.startAddr
+           << "  0x" << std::setw(8) << endAddr
+           << "\n";
+  }
+
+  dbgstr << std::dec << "\nTotal memory usages = "
+         << (double)maxEnd / (1024.0 * 1024.0) << " mb\n";
+
+  pOS << dbgstr.str();
+}
+
+void LinearScanMemAlloc::dump() const { print(errs()); }
+
+LinearScanMemAlloc::AllocEntries
+LinearScanMemAlloc::getSortedAllocatedRegions(const LIs& pLIs) const
+{
+  AllocEntries allocs;
+  for (const LiveInterval* li : pLIs) {
+    Value* v = const_cast<Value*>(li->getValue());
+    auto entIt = m_ValToAllocEntry.find(v);
+    if (entIt != m_ValToAllocEntry.end())
+      allocs.push_back(entIt->second);
+  }
+
+  // sort by starting address
+  std::sort(allocs.begin(), allocs.end(),
+            [] (const AllocEntry& pA, const AllocEntry& pB) {
+              return pA.startAddr < pB.startAddr;
+            });
+
+  return allocs;
+}
+
+LinearScanMemAlloc::AllocEntry
+LinearScanMemAlloc::getAnEmptyRegion(
+  const LinearScanMemAlloc::AllocEntries& pAllocs,
+  uint64_t pRequiredSize, uint64_t pAlignment) const
+{
+  uint64_t startAddr = 0;
+  for (const AllocEntry& alloc : pAllocs) {
+    if (HasConflict(alloc.startAddr, alloc.size, startAddr, pRequiredSize)) {
+      startAddr = GetAlignedAddr(alloc.startAddr + alloc.size, pAlignment);
+      continue;
+    }
+
+    // Ok we find an empty region.
+    //
+    // Note! pAllocs is sorted by startAddr, so if end address of new allocation
+    // is <= current allocated start address, that means we won't have conflict
+    // with other unchecked regions since these regions must have start address
+    // > new allocation's end address.
+    if ((startAddr + pRequiredSize) <= alloc.startAddr)
+      break;
+  }
+  return AllocEntry(startAddr, pRequiredSize);
+}
+
+//===----------------------------------------------------------------------===//
+// Factory method
+//===----------------------------------------------------------------------===//
+char LinearScanMemAlloc::ID = 0;
+
+namespace onnc
+{
+  INITIALIZE_TB_PASS(LinearScanMemAlloc, "LinearScanMemAlloc")
+}
+
+ModulePass* onnc::CreateLinearScanMemAllocPass(TargetBackend* pTB)
+{
+  return new LinearScanMemAlloc(pTB);
+}

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -96,6 +96,7 @@ ONNC_SOURCES = \
 	Analysis/NodeIRScheduler.cpp \
 	Analysis/SplitNode.cpp \
 	Analysis/UpdateGraphOutputSize.cpp \
+	CodeGen/BuildMemOperand.cpp \
 	CodeGen/LiveInterval.cpp \
 	CodeGen/LiveIntervals.cpp \
 	CodeGen/LiveValueMatrix.cpp \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -97,6 +97,7 @@ ONNC_SOURCES = \
 	Analysis/SplitNode.cpp \
 	Analysis/UpdateGraphOutputSize.cpp \
 	CodeGen/BuildMemOperand.cpp \
+	CodeGen/LinearScanMemAlloc.cpp \
 	CodeGen/LiveInterval.cpp \
 	CodeGen/LiveIntervals.cpp \
 	CodeGen/LiveValueMatrix.cpp \


### PR DESCRIPTION
1. Implement BuildMemOperand pass to build memory operands for a given compute graph.
2. [Target] Move getMemInfo() from DLATargetBackend to TargetBackend
3. Implement linear memory allocation for each value considering value's liveness.
