### PR TITLE
Fix LiveInterval bug (start == end).

### DIFF
--- a/include/onnc/CodeGen/LiveInterval.h
+++ b/include/onnc/CodeGen/LiveInterval.h
@@ -31,7 +31,7 @@ public:
 
     Segment(SlotIndex pStart, SlotIndex pEnd)
       : m_Start(pStart), m_End(pEnd) {
-      assert(m_Start < m_End && "Invalid liverange segment.");
+      assert(m_Start <= m_End && "Invalid liverange segment.");
     }
 
     /// Return true if the two segments has overlap.

--- a/include/onnc/CodeGen/SlotIndexes.h
+++ b/include/onnc/CodeGen/SlotIndexes.h
@@ -57,6 +57,21 @@ public:
     return m_pTimeSlot->getIndex() < pOther.m_pTimeSlot->getIndex();
   }
 
+  bool operator==(const SlotIndex& pOther) const
+  {
+    return m_pTimeSlot->getIndex() == pOther.m_pTimeSlot->getIndex();
+  }
+
+  bool operator<=(const SlotIndex& pOther) const
+  {
+    return m_pTimeSlot->getIndex() <= pOther.m_pTimeSlot->getIndex();
+  }
+
+  bool operator>=(const SlotIndex& pOther) const
+  {
+    return m_pTimeSlot->getIndex() >= pOther.m_pTimeSlot->getIndex();
+  }
+
   unsigned getIndex() const { return m_pTimeSlot->getIndex(); }
 
 private:


### PR DESCRIPTION
The start will equal end if the Value is unused.