### PR TITLE
Fix PassManager bug

### DIFF
--- a/lib/Core/PassManager.cpp
+++ b/lib/Core/PassManager.cpp
@@ -105,6 +105,12 @@ void PassManager::doAdd(Pass* pPass, TargetBackend* pBackend, State& pState)
 
     for (Pass::AnalysisID& use : usage) {
       if (hasAdded(use)) {
+        // TODO:
+        // We need to check whether any previous pass clobber the 'use' pass
+        // result. If so, we need to add the 'use' pass to execution queue.
+        //
+        // TODO:
+        // Need a mechanism for each pass to return clobber information.
         DepNode* dep_node = findNode(use);
         assert(dep_node && "dependency node doesn't exist?!");
         // add dependency.

--- a/lib/Core/PassManager.cpp
+++ b/lib/Core/PassManager.cpp
@@ -71,6 +71,13 @@ void PassManager::doAdd(Pass* pPass, TargetBackend* pBackend, State& pState)
   if (hasAdded(pPass->getPassID()))
     return;
 
+  // Execution queue insertion point (position). Dependent passes are inserted
+  // at this point (before pPass).
+  // E.g. Z -> Y -> X (Z dependent on Y .. and so on.)
+  // If we only doAdd(Z), then Y and X are inserted before Z in the execution
+  // queue.
+  ExecutionOrder::iterator exeQueueInsertPt = pState.execution.end() - 1;
+
   std::stack<DepNode*> stack;
   DepNode* cur_node = addNode(*pPass);
   stack.push(cur_node);
@@ -120,6 +127,11 @@ void PassManager::doAdd(Pass* pPass, TargetBackend* pBackend, State& pState)
       // add dependency for cur_node.
       m_Dependencies.connect(*new_node, *cur_node);
       resolver->add(use, *new_pass);
+
+      // Retrieve the insertion point. Later, if there is any new dependent
+      // pass, it will be added before new_pass in terms of execution order.
+      exeQueueInsertPt = pState.execution.insert(exeQueueInsertPt,
+                                                 new_pass->getPassID());
 
       // continue traverse dependency of new node.
       stack.push(new_node);

--- a/tools/unittests/PassManagerTest.cpp
+++ b/tools/unittests/PassManagerTest.cpp
@@ -249,12 +249,25 @@ SKYPAT_F(PassManagerTest, run_test_1)
   pm.add(new Y(), state);
   pm.add(new Z(), state);
 
-  ASSERT_EQ(state.execution.size(), 3); // ZYZ
+  ASSERT_EQ(state.execution.size(), 5); // XYZYZ
   ASSERT_FALSE(state.changed);
 
   Module module;
 
   std::string process;
+
+  // run X: changed
+  ASSERT_TRUE(pm.step(module, state));
+  process += state.pass->getPassName();
+  ASSERT_EQ(state.execution.size(), 4); // YZYZ
+  ASSERT_TRUE(state.changed);
+
+  // run Y: no changed
+  ASSERT_TRUE(pm.step(module, state));
+  process += state.pass->getPassName();
+  ASSERT_EQ(state.execution.size(), 3); // ZYZ
+  ASSERT_TRUE(state.changed);
+
   // run Z(1): retry
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
@@ -346,6 +359,6 @@ SKYPAT_F(PassManagerTest, run_test_1)
   ASSERT_TRUE(state.changed);
 
   errs() << process << std::endl;
-  ASSERT_TRUE(process == "ZXYZXYZYZXYZXYZ");
+  ASSERT_TRUE(process == "XYZXYZXYZYZXYZXYZ");
   ASSERT_TRUE(pm.run(module, state));
 }


### PR DESCRIPTION
[PassManager] Add dependent passes to exe queue for an adding pass.
    
E.g. Z -> Y -> X (Z dependent on Y, and Y dependent on X.)
If we only doAdd(Z), then Y and X are inserted before Z in the
execution queue.