### PR TITLE
PassManager Fix.

### DIFF
--- a/include/onnc/Analysis/LivenessAnalysis.h
+++ b/include/onnc/Analysis/LivenessAnalysis.h
@@ -62,11 +62,11 @@ public:
 
   void print(OStream& pOS, const Module* pModule) const override;
 
+  /// delete LiveIntervals in m_LiveIntervals
+  void clear() override;
+
 private:
   void calculateLiveness(xGraph &pGraph);
-
-  /// delete LiveIntervals in m_LiveIntervals
-  void clear();
 
 private:
   LiveIntervalList m_LiveIntervals;

--- a/include/onnc/Analysis/MemoryAllocation.h
+++ b/include/onnc/Analysis/MemoryAllocation.h
@@ -55,6 +55,8 @@ public:
 
   void print(OStream& pOS, const Module* pModule) const override;
 
+  void clear() override;
+
 private:
   /// Return total size of this allocation.
   uint64_t allocByLiveness(xGraph &pGraph,
@@ -63,8 +65,6 @@ private:
 
   /// delete MemAllocEntries of graph.
   void clearGraphAlloc(xGraph *pGraph);
-
-  void clear();
 
 private:
   GraphMemAllocList m_GraphMemAllocList;

--- a/include/onnc/Analysis/NodeIRScheduler.h
+++ b/include/onnc/Analysis/NodeIRScheduler.h
@@ -70,6 +70,13 @@ public:
 
   void print(OStream& pOS, const Module* pModule) const override;
 
+  void clear() override
+  {
+    m_SchedTimeLine.clear();
+    m_ExeResUsers.clear();
+    m_CurCycle = 0;
+  }
+
 private:
   Nodes greedyPickNextNodes(Nodes &pCands);
 
@@ -80,13 +87,6 @@ private:
   void addExeResUser(const ExeResource *pExeRes, xNode *pUser);
 
   Nodes issue();
-
-  void clear()
-  {
-    m_SchedTimeLine.clear();
-    m_ExeResUsers.clear();
-    m_CurCycle = 0;
-  }
 
 private:
   DLATargetBackend* m_DLATB;

--- a/include/onnc/CodeGen/LinearScanMemAlloc.h
+++ b/include/onnc/CodeGen/LinearScanMemAlloc.h
@@ -13,7 +13,7 @@
 namespace onnc {
 
 class LiveInterval;
-class LiveIntervals;
+class LiveIntervalsData;
 class LiveValueMatrix;
 class TargetBackend;
 class TargetMemInfo;
@@ -51,7 +51,7 @@ private:
                               uint64_t pAlignment) const;
 private:
   MemAllocData* m_MemAllocData;
-  LiveIntervals* m_LIPass;
+  LiveIntervalsData* m_LIDataPass;
   LiveValueMatrix* m_LiveMatPass;
   TargetMemInfo* m_TMI;
 };

--- a/include/onnc/CodeGen/LiveIntervals.h
+++ b/include/onnc/CodeGen/LiveIntervals.h
@@ -13,27 +13,17 @@
 
 namespace onnc {
 
-class BuildSlotIndexes;
-
 /** \class LiveIntervals
  *  \brief Build live intervals for all onnc::Value of onnc::Module.
- *         Provide utilities for live interval queries.
+ *         Save the building result in LiveIntervalsData.
  */
 class LiveIntervals : public ModulePass
 {
 public:
   static char ID;
 
-  typedef std::unordered_map<Value*, LiveInterval*> ValueIntervalMap;
-
-  typedef std::vector<LiveInterval*> LIs;
-
 public:
-  LiveIntervals()
-    : ModulePass(LiveIntervals::ID), m_ValIntrvls(), m_SlotIndexes(nullptr) {
-  }
-
-  virtual ~LiveIntervals() { clear(); }
+  LiveIntervals() : ModulePass(LiveIntervals::ID) {}
 
   ReturnType runOnModule(Module& pModule) override;
 
@@ -44,40 +34,11 @@ public:
 
   StringRef getPassName() const override { return "LiveIntervals"; }
 
-  bool hasInterval(const Value* pV) const;
-
-  const LiveInterval* getInterval(const Value* pV) const;
-
-  /// Remove a live interval pV from liveness table.
-  void removeLiveInterval(const Value* pV);
-
-  /// Get internal data structure.
-  ValueIntervalMap& getAllIntervals() { return m_ValIntrvls; }
-
-  /// Get all live intervals and sort them by start slot index in increasing
-  /// order.
-  const LIs getSortedIntervals() const;
-
-  unsigned getNumSlots() const { return m_SlotIndexes->getNumSlots(); }
-
-  SlotIndex getSlotIndex(const ComputeOperator* pOp) const
-  {
-    return m_SlotIndexes->getSlotIndex(pOp);
-  }
-
   void print(OStream& pOS, const Module* pModule) const override;
 
 private:
-  /// Delete LiveInterval object.
-  void clear();
-
-  LiveInterval* createEmptyLiveInterval(Value* pV);
-
-  void computeValueInterval(LiveInterval& pLI);
-
-private:
-  ValueIntervalMap m_ValIntrvls;
-  BuildSlotIndexes* m_SlotIndexes;
+  void computeValueInterval(LiveInterval& pLI,
+                            const BuildSlotIndexes& pSlotIndexes);
 };
 
 LiveIntervals* CreateLiveIntervalsPass();

--- a/include/onnc/CodeGen/LiveIntervalsData.h
+++ b/include/onnc/CodeGen/LiveIntervalsData.h
@@ -79,9 +79,8 @@ public:
     m_SlotIndexes = pSlotIndex;
   }
 
-private:
   /// Delete LiveInterval object.
-  void clear();
+  void clear() override;
 
 private:
   ValueIntervalMap m_ValIntrvls;

--- a/include/onnc/CodeGen/LiveIntervalsData.h
+++ b/include/onnc/CodeGen/LiveIntervalsData.h
@@ -1,0 +1,95 @@
+//===- LiveIntervalsData.h ------------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef ONNC_CODEGEN_LIVE_INTERVALS_DATA_H
+#define ONNC_CODEGEN_LIVE_INTERVALS_DATA_H
+#include <onnc/CodeGen/LiveInterval.h>
+#include <onnc/Core/ModulePass.h>
+#include <onnc/Core/PassSupport.h>
+
+namespace onnc {
+
+class BuildSlotIndexes;
+
+/** \class LiveIntervalsData
+ *  \brief A data pass containing live intervals of all onnc::Value in an
+ *         onnc::Module. Provide utilities for live interval queries.
+ */
+class LiveIntervalsData : public ModulePass
+{
+public:
+  static char ID;
+
+  typedef std::unordered_map<Value*, LiveInterval*> ValueIntervalMap;
+
+  typedef std::vector<LiveInterval*> LIs;
+
+public:
+  LiveIntervalsData()
+    : ModulePass(LiveIntervalsData::ID),
+      m_ValIntrvls(), m_SlotIndexes(nullptr) {
+  }
+
+  virtual ~LiveIntervalsData() { clear(); }
+
+  //===--------------------------------------------------------------------===//
+  // Pass methods.
+  //===--------------------------------------------------------------------===//
+  ReturnType runOnModule(Module& pModule) override { return kModuleNoChanged; }
+
+  StringRef getPassName() const override { return "LiveIntervalsData"; }
+
+  void print(OStream& pOS, const Module* pModule) const override;
+
+  //===--------------------------------------------------------------------===//
+  // Query interface.
+  //===--------------------------------------------------------------------===//
+  bool hasInterval(const Value* pV) const;
+
+  const LiveInterval* getInterval(const Value* pV) const;
+
+  /// Get all live intervals and sort them by start slot index in increasing
+  /// order.
+  const LIs getSortedIntervals() const;
+
+  unsigned getNumSlots() const { return m_SlotIndexes->getNumSlots(); }
+
+  SlotIndex getSlotIndex(const ComputeOperator* pOp) const
+  {
+    return m_SlotIndexes->getSlotIndex(pOp);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Add/Remove live interval entry interface.
+  //===--------------------------------------------------------------------===//
+  LiveInterval* createEmptyLiveInterval(Value* pV);
+
+  /// Remove a live interval pV from liveness table.
+  void removeLiveInterval(const Value* pV);
+
+  /// Get internal data structure.
+  ValueIntervalMap& getAllIntervals() { return m_ValIntrvls; }
+
+  void setSlotIndexes(BuildSlotIndexes* pSlotIndex)
+  {
+    m_SlotIndexes = pSlotIndex;
+  }
+
+private:
+  /// Delete LiveInterval object.
+  void clear();
+
+private:
+  ValueIntervalMap m_ValIntrvls;
+  BuildSlotIndexes* m_SlotIndexes;
+};
+
+LiveIntervalsData* CreateLiveIntervalsDataPass();
+
+} // namespace of onnc
+
+#endif

--- a/include/onnc/CodeGen/LiveValueMatrix.h
+++ b/include/onnc/CodeGen/LiveValueMatrix.h
@@ -12,6 +12,8 @@
 
 namespace onnc {
 
+class LiveIntervalsData;
+
 /** \class LiveValueMatrix
  *  \brief Track live interference between onnc::Value pairs. Provide utilities
  *         for live interference queries.
@@ -106,7 +108,7 @@ private:
   /// User count of a LiveInterval in current live segment set.
   LICount m_CurLISet;
 
-  LiveIntervals* m_LIPass;
+  LiveIntervalsData* m_LIDataPass;
 };
 
 LiveValueMatrix* CreateLiveValueMatrixPass();

--- a/include/onnc/CodeGen/LiveValueMatrix.h
+++ b/include/onnc/CodeGen/LiveValueMatrix.h
@@ -70,10 +70,10 @@ public:
 
   void print(OStream& pOS, const Module* pModule) const override;
 
-private:
   /// Delete LiveInterval object.
-  void clear();
+  void clear() override;
 
+private:
   /// For each SlotIndex (ComputeOperator):
   /// 1. Find live intervals which start from SlotIndex i, then add these
   ///    intervals' segments to m_StartWith[i]

--- a/include/onnc/CodeGen/SlotIndexes.h
+++ b/include/onnc/CodeGen/SlotIndexes.h
@@ -116,11 +116,11 @@ public:
 
   void print(OStream& pOS, const Module* pModule) const override;
 
+  /// delete TimeSlots of m_TSList, clear containers, and reset start index.
+  void clear() override;
+
 private:
   TimeSlot* createTimeSlot(ComputeOperator& pOp, unsigned pIdx);
-
-  /// delete TimeSlots of m_TSList, clear containers, and reset start index.
-  void clear();
 
 private:
   TimeSlotList m_TSList;

--- a/include/onnc/Core/InitializePasses.h
+++ b/include/onnc/Core/InitializePasses.h
@@ -21,10 +21,22 @@ void InitializeAnalysisPassOptions();
 //===----------------------------------------------------------------------===//
 // Declarations of every single pass
 //===----------------------------------------------------------------------===//
+/// Analysis Pass:
 void* InitializeGraphLivenessAnalysisPass(PassRegistry&);
 void* InitializeMemoryAllocationPass(PassRegistry&);
 void* InitializeUpdateGraphOutputSizePass(PassRegistry&);
 void* InitializeNodeIRSchedulerPass(PassRegistry&);
+
+/// CodeGen Pass:
+void* InitializeBuildMemOperandPass(PassRegistry&);
+void* InitializeBuildSlotIndexesPass(PassRegistry&);
+void* InitializeFuseInplaceValuePass(PassRegistry&);
+void* InitializeLinearScanMemAllocPass(PassRegistry&);
+void* InitializeLiveIntervalsPass(PassRegistry&);
+void* InitializeLiveIntervalsDataPass(PassRegistry&);
+void* InitializeLiveValueMatrixPass(PassRegistry&);
+void* InitializeMemAllocDataPass(PassRegistry&);
+void* InitializeSetMemOperandPass(PassRegistry&);
 
 void InitializeUpdateGraphOutputSizePassOptions();
 

--- a/include/onnc/Core/Pass.h
+++ b/include/onnc/Core/Pass.h
@@ -42,7 +42,8 @@ public:
 
 public:
   explicit Pass(Kind pKind, char& pPassID)
-    : m_Kind(pKind), m_PassID(&pPassID), m_pResolver(nullptr) { }
+    : m_Kind(pKind), m_PassID(&pPassID), m_pResolver(nullptr),
+      m_TimeStep(0), m_Module(nullptr) { }
 
   virtual ~Pass();
 
@@ -62,6 +63,8 @@ public:
   /// Virtual method overridden by subclasses to do any necessary
   /// finalization before any pass is run.
   virtual ReturnType doFinalization(Module& pModule) { return kModuleNoChanged; }
+
+  virtual void clear() {}
 
   /// Print out the internal state of the pass.
   /// Beware that the module pointer MAY be null.
@@ -95,10 +98,26 @@ public:
   /// the 3rd bit is set
   static bool IsFailed(ReturnType pR) { return (0x0 != (pR & kPassFailure)); }
 
+  unsigned getTimeStep() const { return m_TimeStep; }
+
+  void setTimeStep(unsigned pTime) { m_TimeStep = pTime; }
+
+  const Module* getModule() const { return m_Module; }
+
+  void setModule(Module* pM) { m_Module = pM; }
+
 private:
   Kind m_Kind;
   AnalysisID m_PassID;
   AnalysisResolver* m_pResolver;
+
+  // Executing time step. m_TimeStep and m_Module are used by PassManager to
+  // decide whether a pass needs to execute.
+  // @see PassManager::m_TimeStep
+  unsigned m_TimeStep;
+
+  // Module that pass is processing.
+  Module* m_Module;
 };
 
 } // namespace of onnc

--- a/include/onnc/Core/PassManager.h
+++ b/include/onnc/Core/PassManager.h
@@ -78,6 +78,10 @@ public:
 
   Pass* lookup(Pass::AnalysisID pID);
 
+  void printState(const State& pState, OStream& pOS) const;
+
+  void dumpState(const State& pState) const;
+
 private:
   struct DepNode : public DigraphNode<DepNode>
   {

--- a/include/onnc/Core/PassManager.h
+++ b/include/onnc/Core/PassManager.h
@@ -48,6 +48,9 @@ public:
   /// during adding passes.
   ~PassManager();
 
+  /// add pPass to:
+  /// 1. dependency graph (ignore if pPass.getPassID() has been added before)
+  /// 2. execution queue.
   void add(Pass* pPass);
 
   void add(Pass* pPass, TargetBackend* pBackend);
@@ -77,6 +80,8 @@ public:
   const State& state() const { return m_RunState; }
 
   Pass* lookup(Pass::AnalysisID pID);
+
+  PassRegistry* getPassRegistry() { return m_pPassRegistry; }
 
   void printState(const State& pState, OStream& pOS) const;
 
@@ -114,8 +119,6 @@ private:
   typedef std::map<Pass::AnalysisID, DepNode*> AvailableAnalysisMap;
 
 private:
-  PassRegistry* getPassRegistry() { return m_pPassRegistry; }
-
   /// Dependency graph operator: find a node
   DepNode* findNode(Pass::AnalysisID pID) const;
 
@@ -128,8 +131,10 @@ private:
 
   /// Dependency graph operator
   /// Add a pass to internal dependency graph. Pass is added in DSF order.
-  void addPassToDependencyGraph(Pass* pPass, TargetBackend* pBackend,
-                                State& pState);
+  ///
+  /// @note The function can be called multiple times with the same pPass
+  ///       without side effect.
+  void addPassToDependencyGraph(Pass* pPass, TargetBackend* pBackend);
 
   /// Run the pass
   Pass::ReturnType doRun(Pass& pPass, Module& pModule);

--- a/include/onnc/Core/PassManager.h
+++ b/include/onnc/Core/PassManager.h
@@ -136,6 +136,10 @@ private:
 
   void UpdateExecutionOrder(ExecutionOrder& pOrder);
 
+  /// Add a pass to execution queue. If a pass depends on other passes, the
+  /// dependent passes are added to exe queue unconditionally.
+  void addPassToExeQueue(Pass* pPass, State& pState);
+
 private:
   PassRegistry* m_pPassRegistry;
 

--- a/include/onnc/Core/PassManager.h
+++ b/include/onnc/Core/PassManager.h
@@ -109,9 +109,12 @@ private:
   public:
     StartPass() : ModulePass(ID) { }
 
-    Pass::ReturnType runOnModule(Module &pModule) { return kModuleNoChanged; }
+    Pass::ReturnType runOnModule(Module &pModule) override
+    {
+      return kModuleNoChanged;
+    }
 
-    StringRef getPassName() const { return "start"; }
+    StringRef getPassName() const override { return "start"; }
   };
 
   typedef Digraph<DepNode> PassDependencyLattice;

--- a/include/onnc/Core/PassManager.h
+++ b/include/onnc/Core/PassManager.h
@@ -122,7 +122,10 @@ private:
   /// @retval true If the pass @ref pID has been added.
   bool hasAdded(Pass::AnalysisID pID) const;
 
-  void doAdd(Pass* pPass, TargetBackend* pBackend, State& pState);
+  /// Dependency graph operator
+  /// Add a pass to internal dependency graph. Pass is added in DSF order.
+  void addPassToDependencyGraph(Pass* pPass, TargetBackend* pBackend,
+                                State& pState);
 
   /// Run the pass
   Pass::ReturnType doRun(Pass& pPass, Module& pModule);

--- a/include/onnc/Core/PassManager.h
+++ b/include/onnc/Core/PassManager.h
@@ -113,7 +113,7 @@ private:
   PassRegistry* getPassRegistry() { return m_pPassRegistry; }
 
   /// Dependency graph operator: find a node
-  DepNode* findNode(Pass::AnalysisID pID);
+  DepNode* findNode(Pass::AnalysisID pID) const;
 
   /// Dependency graph operator: add a node
   DepNode* addNode(Pass& pPass);

--- a/include/onnc/IR/Module.h
+++ b/include/onnc/IR/Module.h
@@ -223,6 +223,10 @@ public:
   /// print the information to stderr.
   void dump() const;
 
+  unsigned getTimeStep() const { return m_TimeStep; }
+
+  void setTimeStep(unsigned pTime) { m_TimeStep = pTime; }
+
 private:
   // Graph IR field
   std::shared_ptr<xGraph> m_RootTensorGraph;
@@ -238,6 +242,10 @@ private:
   ComputeOperandList m_ComputeOperands;
   ComputeDefineList m_ComputeDefines;
   ValueList m_Values;
+
+  // Update time step. It's updated by PassManager when ModulePass modify
+  // Module.
+  unsigned m_TimeStep;
 };
 
 template<> void Module::print<Module::OpsetImport>(std::ostream& pOS) const;

--- a/lib/CodeGen/CMakeLists.txt
+++ b/lib/CodeGen/CMakeLists.txt
@@ -4,6 +4,7 @@ add_libonnc_src(
     LinearScanMemAlloc.cpp
     LiveInterval.cpp
     LiveIntervals.cpp
+    LiveIntervalsData.cpp
     LiveValueMatrix.cpp
     MemAllocData.cpp
     SetMemOperand.cpp

--- a/lib/CodeGen/LinearScanMemAlloc.cpp
+++ b/lib/CodeGen/LinearScanMemAlloc.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include <onnc/CodeGen/LinearScanMemAlloc.h>
-#include <onnc/CodeGen/LiveIntervals.h>
+#include <onnc/CodeGen/LiveIntervalsData.h>
 #include <onnc/CodeGen/LiveValueMatrix.h>
 #include <onnc/Core/PassAnalysisSupport.h>
 #include <onnc/Core/PassSupport.h>
@@ -41,19 +41,19 @@ static uint64_t GetAlignedAddr(uint64_t pAddr, uint64_t pAlignment)
 //===----------------------------------------------------------------------===//
 LinearScanMemAlloc::LinearScanMemAlloc(TargetBackend* pTarget)
   : ModulePass(ID), m_MemAllocData(nullptr),
-    m_LIPass(nullptr), m_LiveMatPass(nullptr) {
+    m_LIDataPass(nullptr), m_LiveMatPass(nullptr) {
   m_TMI = pTarget->getMemInfo();
 }
 
 Pass::ReturnType LinearScanMemAlloc::runOnModule(Module& pModule)
 {
-  m_LIPass = getAnalysis<LiveIntervals>();
+  m_LIDataPass = getAnalysis<LiveIntervalsData>();
   m_LiveMatPass = getAnalysis<LiveValueMatrix>();
   m_MemAllocData = getAnalysis<MemAllocData>();
 
   // Allocate memory for each value (live interval).
-  for (const LiveInterval* LI: m_LIPass->getSortedIntervals()) {
-    LiveIntervals::LIs overlappedLIs =
+  for (const LiveInterval* LI: m_LIDataPass->getSortedIntervals()) {
+    LiveIntervalsData::LIs overlappedLIs =
       m_LiveMatPass->getInterferingLiveIntervals(LI);
 
     AllocEntries allocRegions = getSortedAllocatedRegions(overlappedLIs);
@@ -71,7 +71,7 @@ Pass::ReturnType LinearScanMemAlloc::runOnModule(Module& pModule)
 
 void LinearScanMemAlloc::getAnalysisUsage(AnalysisUsage& pUsage) const
 {
-  pUsage.addRequiredID(LiveIntervals::ID);
+  pUsage.addRequiredID(LiveIntervalsData::ID);
   pUsage.addRequiredID(LiveValueMatrix::ID);
   pUsage.addRequiredID(MemAllocData::ID);
 }

--- a/lib/CodeGen/LiveIntervalsData.cpp
+++ b/lib/CodeGen/LiveIntervalsData.cpp
@@ -1,0 +1,94 @@
+//===- LiveIntervalsData.cpp ----------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include <onnc/CodeGen/LiveIntervalsData.h>
+#include <onnc/CodeGen/SlotIndexes.h>
+#include <onnc/Core/PassAnalysisSupport.h>
+
+using namespace onnc;
+
+//===----------------------------------------------------------------------===//
+// LiveIntervalsData
+//===----------------------------------------------------------------------===//
+bool LiveIntervalsData::hasInterval(const Value* pV) const
+{
+  return m_ValIntrvls.find(const_cast<Value*>(pV)) != m_ValIntrvls.end();
+}
+
+const LiveInterval* LiveIntervalsData::getInterval(const Value* pV) const
+{
+  return m_ValIntrvls.find(const_cast<Value*>(pV))->second;
+}
+
+void LiveIntervalsData::removeLiveInterval(const Value* pV)
+{
+  assert(hasInterval(pV) && "The value has no interval.");
+  m_ValIntrvls.erase(const_cast<Value*>(pV));
+}
+
+const LiveIntervalsData::LIs LiveIntervalsData::getSortedIntervals() const
+{
+  LIs liveIntrvls;
+  liveIntrvls.reserve(m_ValIntrvls.size());
+
+  for (auto liIter : m_ValIntrvls)
+    liveIntrvls.push_back(liIter.second);
+
+  // sort the index in increasing order.
+  std::sort(liveIntrvls.begin(), liveIntrvls.end(),
+            [] (const LiveInterval* a, const LiveInterval* b) {
+              return a->beginIndex() < b->beginIndex();
+            });
+  return liveIntrvls;
+}
+
+void LiveIntervalsData::print(OStream& pOS, const Module* pModule) const
+{
+  pOS << "=== Live Intervals Data ===\n";
+  if (m_ValIntrvls.empty()) {
+    pOS << "Empty.\n";
+    return;
+  }
+
+  std::stringstream dbgstr;
+  for (const LiveInterval* li : getSortedIntervals())
+    li->print(dbgstr);
+
+  pOS << dbgstr.str();
+}
+
+void LiveIntervalsData::clear()
+{
+  for (auto liIter : m_ValIntrvls) {
+    LiveInterval* li = liIter.second;
+    delete li;
+  }
+  m_ValIntrvls.clear();
+}
+
+LiveInterval* LiveIntervalsData::createEmptyLiveInterval(Value* pV)
+{
+  assert(!hasInterval(pV) && "Live interval has been created.");
+  LiveInterval* li = new LiveInterval(pV);
+  m_ValIntrvls[pV] = li;
+  return li;
+}
+
+//===----------------------------------------------------------------------===//
+// LiveIntervalsData Factory method
+//===----------------------------------------------------------------------===//
+char LiveIntervalsData::ID = 0;
+
+namespace onnc
+{
+  INITIALIZE_PASS(LiveIntervalsData, "LiveIntervalsData")
+}
+
+LiveIntervalsData* onnc::CreateLiveIntervalsDataPass()
+{
+  return new LiveIntervalsData();
+}

--- a/lib/Core/PassManager.cpp
+++ b/lib/Core/PassManager.cpp
@@ -190,9 +190,9 @@ Pass::ReturnType PassManager::doRun(Pass& pPass, Module& pModule)
   return result;
 }
 
-PassManager::DepNode* PassManager::findNode(Pass::AnalysisID pID)
+PassManager::DepNode* PassManager::findNode(Pass::AnalysisID pID) const
 {
-  AvailableAnalysisMap::iterator entry = m_AvailableAnalysis.find(pID);
+  AvailableAnalysisMap::const_iterator entry = m_AvailableAnalysis.find(pID);
   if (m_AvailableAnalysis.end() == entry)
     return nullptr;
   return entry->second;

--- a/lib/Core/PassManager.cpp
+++ b/lib/Core/PassManager.cpp
@@ -153,10 +153,8 @@ bool PassManager::step(Module& pModule, State& pState)
     return false;
 
   if (Pass::IsRetry(result)) {
-    if (Pass::IsRevised(result)) {
-      UpdateExecutionOrder(pState.execution);
-      pState.changed = false;
-    }
+    UpdateExecutionOrder(pState.execution);
+    pState.changed = false;
   }
   else { //< not retry
     if (Pass::IsRevised(result))

--- a/lib/Core/PassManager.cpp
+++ b/lib/Core/PassManager.cpp
@@ -42,13 +42,13 @@ PassManager::~PassManager()
 // Use depth search first to build up a sub-graph of dependenciess.
 void PassManager::add(Pass* pPass, State& pState)
 {
-  addPassToDependencyGraph(pPass, nullptr, pState);
+  addPassToDependencyGraph(pPass, nullptr);
   addPassToExeQueue(pPass, pState);
 }
 
 void PassManager::add(Pass* pPass, TargetBackend* pBackend, State& pState)
 {
-  addPassToDependencyGraph(pPass, pBackend, pState);
+  addPassToDependencyGraph(pPass, pBackend);
   addPassToExeQueue(pPass, pState);
 }
 
@@ -76,8 +76,7 @@ void PassManager::addPassToExeQueue(Pass* pPass, State& pState)
 }
 
 /// Add a pass by DSF order
-void PassManager::addPassToDependencyGraph(Pass* pPass, TargetBackend* pBackend,
-                                           State& pState)
+void PassManager::addPassToDependencyGraph(Pass* pPass, TargetBackend* pBackend)
 {
   // If the pass is already in the dependency graph, then we don't
   // need to add it into the graph.

--- a/lib/Core/PassManager.cpp
+++ b/lib/Core/PassManager.cpp
@@ -42,12 +42,12 @@ PassManager::~PassManager()
 // Use depth search first to build up a sub-graph of dependenciess.
 void PassManager::add(Pass* pPass, State& pState)
 {
-  doAdd(pPass, nullptr, pState);
+  addPassToDependencyGraph(pPass, nullptr, pState);
 }
 
 void PassManager::add(Pass* pPass, TargetBackend* pBackend, State& pState)
 {
-  doAdd(pPass, pBackend, pState);
+  addPassToDependencyGraph(pPass, pBackend, pState);
 }
 
 // Use depth search first to build up a sub-graph of dependenciess.
@@ -62,7 +62,8 @@ void PassManager::add(Pass* pPass, TargetBackend* pBackend)
 }
 
 /// Add a pass by DSF order
-void PassManager::doAdd(Pass* pPass, TargetBackend* pBackend, State& pState)
+void PassManager::addPassToDependencyGraph(Pass* pPass, TargetBackend* pBackend,
+                                           State& pState)
 {
   pState.execution.push_back(pPass->getPassID());
 

--- a/lib/Core/PassManager.cpp
+++ b/lib/Core/PassManager.cpp
@@ -219,6 +219,27 @@ Pass* PassManager::lookup(Pass::AnalysisID pID)
   return node->pass;
 }
 
+void PassManager::printState(const State& pState, OStream& pOS) const
+{
+  pOS << "Execution queue: ";
+  if (pState.execution.empty()) {
+    pOS << "empty." << std::endl;
+    return;
+  }
+
+  pOS << "Start";
+  for (Pass::AnalysisID id : pState.execution) {
+    DepNode* node = findNode(id);
+    pOS << " -> " << node->pass->getPassName();
+  }
+  pOS << std::endl;
+}
+
+void PassManager::dumpState(const State& pState) const
+{
+  printState(pState, errs());
+}
+
 bool PassManager::hasAdded(Pass::AnalysisID pID) const
 {
   return (m_AvailableAnalysis.end() != m_AvailableAnalysis.find(pID));

--- a/lib/IR/ComputeGraph.cpp
+++ b/lib/IR/ComputeGraph.cpp
@@ -201,7 +201,7 @@ void ComputeGraph::print(std::ostream& pOS) const
 void ComputeGraph::print(json::Value& pValue) const
 {
     const_iterator nodeIter = begin();
-    for(nodeIter; nodeIter != end(); ++nodeIter){
+    for(; nodeIter != end(); ++nodeIter){
       nodeIter->print(pValue);
     }
 }

--- a/lib/IR/Module.cpp
+++ b/lib/IR/Module.cpp
@@ -118,7 +118,8 @@ Module::Module()
     m_OnnxSetId(),
     m_OnnxMetaData(),
     m_pRootComputeGraph(nullptr),
-    m_ComputeGraphs() {
+    m_ComputeGraphs(),
+    m_TimeStep(0) {
 }
 
 Module::Module(std::unique_ptr<xGraph> pGraph)
@@ -128,7 +129,8 @@ Module::Module(std::unique_ptr<xGraph> pGraph)
     m_OnnxSetId(),
     m_OnnxMetaData(),
     m_pRootComputeGraph(nullptr),
-    m_ComputeGraphs() {
+    m_ComputeGraphs(),
+    m_TimeStep(0) {
 }
 
 Module::~Module()
@@ -251,7 +253,7 @@ void Module::printComputeGraph(json::Object& pJSON) const
   // traverse all ComputeGraph
   json::Value a_value;
   const_cg_iterator cgIter = cgBegin();
-  for (cgIter; cgIter != cgEnd(); ++cgIter){
+  for (; cgIter != cgEnd(); ++cgIter){
     cgIter->value()->print(a_value); 
   }
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -263,6 +263,7 @@ ONNC_SOURCES = \
 	CodeGen/LinearScanMemAlloc.cpp \
 	CodeGen/LiveInterval.cpp \
 	CodeGen/LiveIntervals.cpp \
+	CodeGen/LiveIntervalsData.cpp \
 	CodeGen/LiveValueMatrix.cpp \
 	CodeGen/MemAllocData.cpp \
 	CodeGen/SetMemOperand.cpp \

--- a/lib/Target/TargetStandardPasses.cpp
+++ b/lib/Target/TargetStandardPasses.cpp
@@ -13,6 +13,7 @@
 #include <onnc/CodeGen/MemAllocData.h>
 #include <onnc/CodeGen/SetMemOperand.h>
 #include <onnc/CodeGen/SlotIndexes.h>
+#include <onnc/Core/InitializePasses.h>
 #include <onnc/Core/PassManager.h>
 #include <onnc/Target/TargetStandardPasses.h>
 #include <onnc/Transforms/BookONNXGraphs.h>
@@ -52,19 +53,27 @@ void onnc::addStandardTensorSel(PassManager& pPM, TargetBackend& pTB) {
 
 void onnc::addStandardCreateLiveIntervals(PassManager& pPM)
 {
+  PassRegistry& reg = *pPM.getPassRegistry();
   // Build slot id for each onnc ir
-  pPM.add(CreateBuildSlotIndexesPass());
+  InitializeBuildSlotIndexesPass(reg);
+  // Data pass for saving live intervals built by LiveIntervals.
+  InitializeLiveIntervalsDataPass(reg);
   // Build live interval for each value
+  InitializeLiveIntervalsPass(reg);
+
   pPM.add(CreateLiveIntervalsPass());
 }
 
 void onnc::addStandardMemoryAllocation(PassManager& pPM, TargetBackend& pTB)
 {
+  PassRegistry& reg = *pPM.getPassRegistry();
   // Create live matrix for interference query
-  pPM.add(CreateLiveValueMatrixPass());
+  InitializeLiveValueMatrixPass(reg);
   // Create memory allocation data pass for saving allocation result.
-  pPM.add(CreateMemAllocDataPass());
+  InitializeMemAllocDataPass(reg);
   // Standard memory allocation for each value
+  InitializeLinearScanMemAllocPass(reg);
+
   pPM.add(CreateLinearScanMemAllocPass(&pTB));
 }
 

--- a/lib/Target/X86/X86RemoveWeightFromLiveIntervals.cpp
+++ b/lib/Target/X86/X86RemoveWeightFromLiveIntervals.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "X86RemoveWeightFromLiveIntervals.h"
-#include <onnc/CodeGen/LiveIntervals.h>
+#include <onnc/CodeGen/LiveIntervalsData.h>
 #include <onnc/Core/PassAnalysisSupport.h>
 #include <onnc/IR/Compute/Initializer.h>
 #include <onnc/IR/Compute/InputOperator.h>
@@ -18,7 +18,7 @@ using namespace onnc;
 //===----------------------------------------------------------------------===//
 Pass::ReturnType X86RemoveWeightFromLiveIntervals::runOnModule(Module& pModule)
 {
-  LiveIntervals* liveIntrvlPass = getAnalysis<LiveIntervals>();
+  LiveIntervalsData* liveIntrvlPass = getAnalysis<LiveIntervalsData>();
 
   for (auto& valIt : pModule.getValueList()) {
     Value* v = valIt.value();
@@ -35,7 +35,7 @@ Pass::ReturnType X86RemoveWeightFromLiveIntervals::runOnModule(Module& pModule)
 void X86RemoveWeightFromLiveIntervals::getAnalysisUsage(
   AnalysisUsage& pUsage) const
 {
-  pUsage.addRequiredID(LiveIntervals::ID);
+  pUsage.addRequiredID(LiveIntervalsData::ID);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/X86/X86RemoveWeightFromLiveIntervals.h
+++ b/lib/Target/X86/X86RemoveWeightFromLiveIntervals.h
@@ -29,6 +29,8 @@ public:
   ReturnType runOnModule(Module& pModule) override;
 
   void getAnalysisUsage(AnalysisUsage& pUsage) const override;
+
+  StringRef getPassName() const override { return "X86RemoveWeightFromLiveIntervals"; }
 };
 
 X86RemoveWeightFromLiveIntervals* CreateX86RemoveWeightFromLiveIntervalsPass();

--- a/tools/unittests/PassManagerTest.cpp
+++ b/tools/unittests/PassManagerTest.cpp
@@ -219,7 +219,7 @@ public:
       return kModuleChanged;
 
     // retry till c is 3
-    return (kPassRetry | kModuleChanged);
+    return kPassRetry;
   }
 
   void getAnalysisUsage(AnalysisUsage& pUsage) const override {

--- a/tools/unittests/PassManagerTest.cpp
+++ b/tools/unittests/PassManagerTest.cpp
@@ -248,54 +248,79 @@ SKYPAT_F(PassManagerTest, run_test_1)
   pm.add(new Z(), state);
   pm.add(new Y(), state);
   pm.add(new Z(), state);
-
-  ASSERT_EQ(state.execution.size(), 3); // ZYZ
+  ASSERT_EQ(state.execution.size(), 8); // XYZXYXYZ
   ASSERT_FALSE(state.changed);
 
   Module module;
 
   std::string process;
+
+  // run X
+  ASSERT_TRUE(pm.step(module, state));
+  process += state.pass->getPassName();
+  ASSERT_EQ(state.execution.size(), 7); // YZXYXYZ
+
+  // run Y
+  ASSERT_TRUE(pm.step(module, state));
+  process += state.pass->getPassName();
+  ASSERT_EQ(state.execution.size(), 6); // ZXYXYZ
+
   // run Z(1): retry
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
-  ASSERT_EQ(state.execution.size(), 5); // XYZYZ
+  ASSERT_EQ(state.execution.size(), 8); // XYZXYXYZ
   ASSERT_FALSE(state.changed);
 
   // run X: changed
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
-  ASSERT_EQ(state.execution.size(), 4); // YZYZ
+  ASSERT_EQ(state.execution.size(), 7); // YZXYXYZ
   ASSERT_TRUE(state.changed);
 
   // run Y: no changed
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
-  ASSERT_EQ(state.execution.size(), 3); // ZYZ
+  ASSERT_EQ(state.execution.size(), 6); // ZXYXYZ
   ASSERT_TRUE(state.changed);
 
   // run Z(2): retry
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
-  ASSERT_EQ(state.execution.size(), 5); // XYZYZ
+  ASSERT_EQ(state.execution.size(), 8); // XYZXYXYZ
   ASSERT_FALSE(state.changed);
 
   // run X: changed
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
-  ASSERT_EQ(state.execution.size(), 4); // YZYZ
+  ASSERT_EQ(state.execution.size(), 7); // YZXYXYZ
   ASSERT_TRUE(state.changed);
 
   // run Y: no changed
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
-  ASSERT_EQ(state.execution.size(), 3); // ZYZ
+  ASSERT_EQ(state.execution.size(), 6); // ZXYXYZ
   ASSERT_TRUE(state.changed);
 
   // run Z(3): changed
   ASSERT_TRUE(pm.step(module, state));
   process += state.pass->getPassName();
-  ASSERT_EQ(state.execution.size(), 2); // YZ
+  ASSERT_EQ(state.execution.size(), 5); // XYXYZ
   ASSERT_TRUE(state.changed);
+
+  // run X
+  ASSERT_TRUE(pm.step(module, state));
+  process += state.pass->getPassName();
+  ASSERT_EQ(state.execution.size(), 4); // YXYZ
+
+  // run Y
+  ASSERT_TRUE(pm.step(module, state));
+  process += state.pass->getPassName();
+  ASSERT_EQ(state.execution.size(), 3); // XYZ
+
+  // run X
+  ASSERT_TRUE(pm.step(module, state));
+  process += state.pass->getPassName();
+  ASSERT_EQ(state.execution.size(), 2); // YZ
 
   // run Y: no changed
   ASSERT_TRUE(pm.step(module, state));
@@ -346,6 +371,6 @@ SKYPAT_F(PassManagerTest, run_test_1)
   ASSERT_TRUE(state.changed);
 
   errs() << process << std::endl;
-  ASSERT_TRUE(process == "ZXYZXYZYZXYZXYZ");
+  ASSERT_TRUE(process == "XYZXYZXYZXYXYZXYZXYZ");
   ASSERT_TRUE(pm.run(module, state));
 }


### PR DESCRIPTION
  PassManager::run behaviour:
  1. If a pass dependents on other passes (cyclic dependency is disallowed),
     PassManager guarantees all dependencies are executed before that pass.
  
  2. PassManager doesn't re-execute a pass if that pass's dependencies are
     unchanged.
  
  3. If a pass return retry, PassManager re-executes that pass, but whether
     re-executes it's dependencies or not follows rule 2.

If we have passes: Z -> Y, and Y -> X, and we add in this manner:
      pm.add(Z)
      pm.add(Y)
      pm.add(Z)

The execution order:
    before this patch: ZYZ
    after this patch: (a) if Z modify Module, X, Y doesn't : XYZXYZ
                                (b) if X, Y, Z doesn't modify Module: X Y Z

Please help me to make sure this is what we want.