### PR TITLE
cmake find_package(onnc)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,3 +131,4 @@ configure_file(include/onnc/Config/Config.h.cmake.in include/onnc/Config/Config.
 configure_file(include/onnc/Config/ONNX.h.in include/onnc/Config/ONNX.h @ONLY)
 configure_file(include/onnc/Config/Platforms.def.in include/onnc/Config/Platforms.def @ONLY)
 configure_file(include/onnc/Config/Backends.def.in include/onnc/Config/Backends.def @ONLY)
+configure_file(cmake/ONNCConfig.cmake.in cmake/ONNCConfig.cmake @ONLY)

--- a/cmake/ONNCConfig.cmake.in
+++ b/cmake/ONNCConfig.cmake.in
@@ -1,0 +1,5 @@
+# This file provides information and services to the final user.
+
+set(ONNC_INCLUDE_DIRS "@LIBONNC_INCLUDES@")
+set(ONNC_LDFLAGS "@LIBONNC_LIBS@")
+set(ONNC_LIBRARY_DIR "@LIBONNC_LIBS@")

--- a/configure.ac
+++ b/configure.ac
@@ -100,5 +100,6 @@ AC_CONFIG_FILES([tools/onnc/Makefile])
 AC_CONFIG_FILES([tools/readonnx/Makefile])
 AC_CONFIG_FILES([tools/onnc-jit/Makefile])
 AC_CONFIG_FILES([tools/onni/Makefile])
+AC_CONFIG_FILES([cmake/ONNCConfig.cmake])
 
 AC_OUTPUT


### PR DESCRIPTION
To help outside cmake project to use ONNC, we need to provide a cmake description `ONNCConfig.cmake` for their import.

In this patch, I create a new template file `ONNCConfig.cmake.in`, and modify `configure.ac` and `src/CMakeList.txt` to substitude keywords.