### PR TITLE
Fix: unit test Runtime_Abs random failure

### DIFF
--- a/tools/unittests/Runtime/AbsTest.cpp
+++ b/tools/unittests/Runtime/AbsTest.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <cmath>
+#include <vector>
 
 #define restrict __restrict__
 extern "C"{
@@ -13,23 +14,23 @@ SKYPAT_F(Operator_Abs, non_broadcast){
     // Prepare
     srand(time(NULL));
     int32_t ndim = rand() % 3 + 1;
-    int32_t dims[ndim];
+    std::vector<int32_t> dims(ndim);
     int32_t dataSize = 1;
     for(int32_t i = 0; i < ndim; ++i){
         dims[i] = rand() % 100 + 1;
         dataSize *= dims[i];
     }
-    float A[dataSize], B[dataSize], Ans[dataSize];
+    std::vector<float> A(dataSize), B(dataSize), Ans(dataSize);
     for(int32_t i = 0; i < dataSize; ++i){
         A[i] = rand() % 1000 / 100;
         Ans[i] = (A[i] > 0) ? A[i] : -A[i];
     }
     // Run
     ONNC_RUNTIME_abs_float(NULL
-        ,A
-        ,ndim,dims
-        ,B
-        ,ndim,dims
+        ,A.data()
+        ,ndim,dims.data()
+        ,B.data()
+        ,ndim,dims.data()
     );
     // Check
     for(int32_t i = 0; i < dataSize; ++i){


### PR DESCRIPTION
`[Problem]`  
There are very low probability to meet  segmentation fault when run the unit test **Runtime_Abs**

`[Root Cause]`  
In worst case, we will allocate 3 float arrays each size is 100^3, it's very large for a scoped array on stack.

`[Solution]`  
Avoid use variable-length array which might cause segmentation fault, Use **std::vector** for dynamic memory allocation.