### PR TITLE
Fix: TargetBackend object leak in onnc

### DIFF
--- a/lib/Target/NvDla/NvDlaMeta.cpp
+++ b/lib/Target/NvDla/NvDlaMeta.cpp
@@ -122,6 +122,8 @@ NvDlaBackendMeta::~NvDlaBackendMeta()
     NVDLA_DBG("LUT release - %p\n", lut);
     delete lut;
   }
+
+  priv::LoadableFactory::deleteLoadable(m_Loadable.i());
 }
 
 #define ELEMENT_SIZE 2

--- a/tools/onnc/ONNCApp.cpp
+++ b/tools/onnc/ONNCApp.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "ONNCApp.h"
-#include <cstdlib>
+
 #include <onnc/Target/TargetSelect.h>
 #include <onnc/Target/TargetRegistry.h>
 #include <onnc/Target/TargetBackend.h>
@@ -17,6 +17,10 @@
 #include <onnc/Core/PassManager.h>
 #include <onnc/ADT/Color.h>
 #include <onnc/Support/IOStream.h>
+
+#include <cstdlib>
+
+#include <memory>
 #include <string>
 
 using namespace onnc;
@@ -57,7 +61,7 @@ int ONNCApp::compile()
   }
 
   PassManager pm;
-  TargetBackend* backend = target->createBackend(options().target());
+  const auto backend = std::unique_ptr<TargetBackend>(target->createBackend(options().target()));
   backend->addTensorSel(pm);
   backend->addTensorSched(pm);
   backend->addMemAlloc(pm);


### PR DESCRIPTION
`[Problem]`  
Memory leak occurs when running **onnc** to compile models.

`[Root Cause]`  
1. The program **onnc** never destroys the created `TargetBackend` object.
2. `NvDlaBackend` does not release all acquired memory.

`[Solution]`  
Add correspond resource release logics.