### PR TITLE
fix one typo on ONNC-Utilities.md #4

### DIFF
--- a/docs/ONNC-Utilities.md
+++ b/docs/ONNC-Utilities.md
@@ -56,7 +56,7 @@ $ cd /onnc/onnc-umbrella
 $ ssync && ./build.cmake.sh <build_mode>
 ```
 
-`<build_mode>` supports one of the following mode:
+`<build_mode>` supports one of the following modes:
 
 ```
 normal, dbg, rgn, opt 


### PR DESCRIPTION
In section "Configure Build Environment": <build_mode> supports one of the following "mode" -> modes