### PR TITLE
[onnc] update version in loadable and onnc help message

### DIFF
--- a/lib/Target/NvDla/NvDlaBackend.cpp
+++ b/lib/Target/NvDla/NvDlaBackend.cpp
@@ -76,9 +76,9 @@ namespace onnc {
 //===----------------------------------------------------------------------===//
 // NvDlaBackend
 //===----------------------------------------------------------------------===//
-const Version NvDlaBackend::LOADABLE_VERSION = Version(1, 1, 255);
-const Version NvDlaBackend::BLOB_DLA_VERSION = Version(1, 3, 0);
-const Version NvDlaBackend::BLOB_EMU_VERSION = Version(1, 3, 0);
+const Version NvDlaBackend::LOADABLE_VERSION = Version(1, 1, 1);
+const Version NvDlaBackend::BLOB_DLA_VERSION = Version(1, 2, 0);
+const Version NvDlaBackend::BLOB_EMU_VERSION = Version(1, 2, 0);
 
 NvDlaBackend::NvDlaBackend(const TargetOptions& pOptions)
   : TargetBackend{pOptions}

--- a/single_layer_test/compile-models.sh
+++ b/single_layer_test/compile-models.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 MODELS=($(find $SCRIPT_DIR -iname "*.onnx"))
 
-ONNC=./tools/onnc/onnc
+ONNC=onnc
 
 for model in "${MODELS[@]}"; do
   model_dir="$(dirname $model)"

--- a/tools/onnc/main.cpp
+++ b/tools/onnc/main.cpp
@@ -16,7 +16,7 @@ using namespace onnc;
 
 static AboutData g_About("onnc",
                          "onnc",
-                         "0.1.0",
+                         "1.2.0",
                          AboutLicense::kPrivate,
                          "ONNC is the compiler driver");
 


### PR DESCRIPTION
**[Problem]** 
1. The onnc version is 1.2.0 now, but help message and version in NVDLA loadable is not match.
2. Use wrong onnc path in *compile-models.h*

**[Solution]** 
1. Sync onnc help message& NVDLA loadable version
2. Always use onnc in the `PATH` variable
